### PR TITLE
Add sorting of cipher suites.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,14 +1,11 @@
 % -*- mode: erlang -*-
+{require_min_otp_vsn, "19"}. % and max 21
 {erl_opts, [
     debug_info,
-    {platform_define, "^[0-9]+", has_maps},
-    {platform_define, "^(R14|R15|R16B-)", 'crypto_compatibility'},
-    {platform_define, "^(R14|R15|R16B|17)", 'rand_mod_unavailable'},
-    {platform_define, "^(R14|R15|R16B|17)", 'sni_unavailable'},
-    {platform_define, "^(R14|R15|R16)", 'map_unavailable'},
-    {platform_define, "^(R14|R15|R16|17|18|19|20)", 'ssl_handshake_unavailable'},
-    {platform_define, "^(R14|R15|R16|17|18|19|20)", 'ssl_cipher_old'},
-    {platform_define, "^(R14|R15|R16|17|18|19|20|21)", 'ssl_filter_broken'},
+
+    {platform_define, "^(19|20)", 'ssl_handshake_unavailable'},
+    {platform_define, "^(19|20)", 'ssl_cipher_old'},
+    {platform_define, "^(19|20|21)", 'ssl_filter_broken'},
     {platform_define, "^21", 'otp_21'}
 ]}.
 {cover_enabled, true}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 % -*- mode: erlang -*-
-{require_min_otp_vsn, "19"}. % and max 21
+{require_min_otp_vsn, "19"}. % and max 22
 {erl_opts, [
     debug_info,
 

--- a/src/mochiweb_socket.erl
+++ b/src/mochiweb_socket.erl
@@ -83,7 +83,10 @@ suite_definition(Suite) ->
 % Return true if the cipher algorithm is secure.
 is_secure_cipher(des_cbc) -> false;
 is_secure_cipher(rc4_128) -> false;
-is_secure_cipher(_) -> true.
+is_secure_cipher('3des_ede_cbc') -> false;
+is_secure_cipher(aes_128_cbc) -> false;
+is_secure_cipher(_) ->
+    true.
 
 % Return true if the mac algorithm is secure.
 is_secure_mac(md5) -> false;

--- a/src/mochiweb_socket.erl
+++ b/src/mochiweb_socket.erl
@@ -17,7 +17,8 @@ listen(Ssl, Port, Opts, SslOpts) ->
         true ->
             Opts1 = add_unbroken_ciphers_default(Opts ++ SslOpts),
             Opts2 = add_safe_protocol_versions(Opts1),
-            case ssl:listen(Port, Opts2) of
+            Opts3 = add_honor_cipher_order(Opts2),
+            case ssl:listen(Port, Opts3) of
                 {ok, ListenSocket} ->
                     {ok, {ssl, ListenSocket}};
                 {error, _} = Err ->
@@ -25,6 +26,15 @@ listen(Ssl, Port, Opts, SslOpts) ->
             end;
         false ->
             gen_tcp:listen(Port, Opts)
+    end.
+
+% Add the honor_cipher_order flag when not set in the options. 
+add_honor_cipher_order(Opts) ->
+    case proplists:get_value(honor_cipher_order, Opts) of
+        undefined ->
+            [{honor_cipher_order, true} | Opts];
+        _ ->
+            Opts
     end.
 
 -ifdef(ssl_filter_broken).

--- a/src/mochiweb_socket.erl
+++ b/src/mochiweb_socket.erl
@@ -81,10 +81,8 @@ suite_definition(Suite) ->
 -endif.
 
 % Return true if the key_exchange algorithm is secure
-
 is_secure_key_exchange(rsa) -> false; 
 is_secure_key_exchange(Alg) -> 
-    io:fwrite(standard_error, "key_exchange: ~p~n", [Alg]),
     case atom_to_list(Alg) of
         "ecdh_" ++ _ -> false;
         _ -> true
@@ -95,8 +93,7 @@ is_secure_cipher(des_cbc) -> false;
 is_secure_cipher(rc4_128) -> false;
 is_secure_cipher('3des_ede_cbc') -> false;
 is_secure_cipher(aes_128_cbc) -> false;
-is_secure_cipher(_) ->
-    true.
+is_secure_cipher(_) -> true.
 
 % Return true if the mac algorithm is secure.
 is_secure_mac(md5) -> false;

--- a/src/mochiweb_socket.erl
+++ b/src/mochiweb_socket.erl
@@ -54,10 +54,10 @@ sort_cipher_suites(Suites) ->
     
 suite_sort_info(Suite) ->
   SuiteInfo = suite_definition(Suite),
-  {cipher_level(SuiteInfo),
-   has_ec_key_exchange(SuiteInfo),
+  {has_ec_key_exchange(SuiteInfo),
    has_aead(SuiteInfo),
    has_ecdsa(SuiteInfo),
+   cipher_level(SuiteInfo),
    effective_key_bits(SuiteInfo),
    hash_size(SuiteInfo)}.
 

--- a/src/mochiweb_socket.erl
+++ b/src/mochiweb_socket.erl
@@ -38,9 +38,9 @@ add_unbroken_ciphers_default(Opts) ->
 
 % Sort the cipher suite in more preferred secure order to less.
 sort_cipher_suites(Suites) ->
-    lists:sort(fun(A, B) ->
-                       suite_sort_info(A) =< suite_definition(B)
-               end, Suites). 
+    lists:reverse(lists:sort(fun(A, B) ->
+                                     suite_sort_info(A) =< suite_definition(B)
+                             end, Suites)). 
     
 suite_sort_info(Suite) ->
   SuiteInfo = suite_definition(Suite),

--- a/src/mochiweb_socket.erl
+++ b/src/mochiweb_socket.erl
@@ -119,6 +119,8 @@ add_safe_protocol_versions(Opts) ->
 filter_unsafe_protcol_versions(Versions) ->
     lists:filter(fun
                     (sslv3) -> false;
+                    (tlsv1) -> false;
+                    ('tlsv1.1') -> false;
                     (_) -> true
                  end,
                  Versions).


### PR DESCRIPTION
For a semi-government client we had to change the way mochiweb collects its ciphers.

- Disables the use of tlsv1.1
- Disabes the use of 3des_ede_cbc
- Adds sorting of cipher suite from more secure to less as default for otp 19, 20 and 21
- Adds `{honor_cipher_order, true}` as default for otp 19, 20 and 21
- Remove some old conditional compilation code of no longer supported erlang versions.

For sorting the guidelines from https://english.ncsc.nl/publications/publications/2019/juni/01/it-security-guidelines-for-transport-layer-security-tls have been used.

